### PR TITLE
updated lineFmt test - increased limit to 2002

### DIFF
--- a/e2e.logql.reader.js
+++ b/e2e.logql.reader.js
@@ -199,7 +199,7 @@ _it('should hammer unwrap', async () => {
 _itShouldMatrixReq(`unwrap + json params`,
     `sum_over_time({test_id="${testID}_json"}|json lbl_int1="int_val"` +
     '|lbl_repl="val_repl"|unwrap lbl_int1 [3s]) by (test_id, lbl_repl)')
-_itShouldStdReq({name: 'lineFmt', limit: '2001', req: `{test_id="${testID}"}| line_format ` +
+_itShouldStdReq({name: 'lineFmt', limit: '2002', req: `{test_id="${testID}"}| line_format ` +
     '"{ \\"str\\":\\"{{._entry}}\\", \\"freq2\\": {{div .freq 2}} }"'})
 _it('linefmt + json + unwrap', async() => {
     const resp = await runRequest(`rate({test_id="${testID}"}` +


### PR DESCRIPTION
This pull request includes a minor update to the `e2e.logql.reader.js` test file. The change adjusts the `limit` parameter value in a test case to ensure consistency or accommodate updated requirements.

* Test case adjustment:
  * Updated the `limit` parameter in `_itShouldStdReq` from `2001` to `2002` in the test definition for `lineFmt`. (`[e2e.logql.reader.jsL202-R202](diffhunk://#diff-1ff6ba510b76f74f3c7c3f129d482f0897e6669392fc8e33bc776a373afead14L202-R202)`)